### PR TITLE
audioread 3.1.0

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,0 +1,4 @@
+anaconda_config_version: 1
+upstream_sources:
+  - pypi:
+      identifier: audioread

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ test:
     - pip check
   requires:
     - pip
+    - pytest
+    - pytest-runner
 
 about:
   home: https://github.com/beetbox/audioread

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,9 @@ requirements:
     - python
     - pip
     - poetry-core
+    # ffmpeg is pinned in the aggregate CBC; mirror it into host so the pin applies
+    # (audioread invokes the ffmpeg binary at runtime as a decode backend).
+    - ffmpeg  # [not win]
   run:
     - python
     - ffmpeg  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0.0" %}
+{% set version = "3.1.0" %}
 
 package:
   name: audioread
@@ -6,30 +6,32 @@ package:
 
 source:
   fn: audioread-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/a/audioread/audioread-{{ version }}.tar.gz
-  sha256: 121995bd207eb1fda3d566beb851d3534275925bc35a4fb6da0cb11de0f7251a
+  url: https://pypi.org/packages/source/a/audioread/audioread-{{ version }}.tar.gz
+  sha256: 1c4ab2f2972764c896a8ac61ac53e261c8d29f0c6ccd652f84e18f08a4cab190
 
 build:
-  number: 1
-  script: python -m pip install . --no-deps -vv
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
     - python
     - pip
+    - poetry-core
   run:
     - python
     - ffmpeg  # [not win]
+    # aifc/sunau were removed from the stdlib in 3.13; audioread's raw decoder needs them.
+    - standard-aifc  # [py>=313]
+    - standard-sunau  # [py>=313]
 
 test:
-  requires:
-    - pytest
-    - pytest-runner
   imports:
     - audioread
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/beetbox/audioread
@@ -37,6 +39,12 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: multi-library, cross-platform audio decoding
+  description: |
+    audioread is a cross-platform, multi-library wrapper for decoding audio
+    through whichever backend is available (FFmpeg, GStreamer, Core Audio, MAD,
+    or the standard-library WAV/AIFF/AU readers).
+  doc_url: https://github.com/beetbox/audioread
+  dev_url: https://github.com/beetbox/audioread
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,9 +18,9 @@ requirements:
     - python
     - pip
     - poetry-core
-    # ffmpeg is pinned in the aggregate CBC; mirror it into host so the pin applies
-    # (audioread invokes the ffmpeg binary at runtime as a decode backend).
-    - ffmpeg  # [not win]
+    # ffmpeg is pinned in the aggregate CBC; mirror it into host with the pin so it
+    # applies (audioread invokes the ffmpeg binary at runtime as a decode backend).
+    - ffmpeg {{ ffmpeg }}  # [not win]
   run:
     - python
     - ffmpeg  # [not win]


### PR DESCRIPTION
audioread 3.1.0

**Destination channel:** defaults

### Links

- [PKG-15706](https://anaconda.atlassian.net/browse/PKG-15706)
- [Upstream repository](https://github.com/beetbox/audioread)
- [PyPI](https://pypi.org/project/audioread/3.1.0/)

### Explanation of changes:

- Updated audioread from 3.0.0 to 3.1.0 


[PKG-15706]: https://anaconda.atlassian.net/browse/PKG-15706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ